### PR TITLE
Disable query cache as it's causing issues with current schema.

### DIFF
--- a/memeolist/app/src/main/java/org/aerogear/android/app/memeolist/sdk/SyncClient.java
+++ b/memeolist/app/src/main/java/org/aerogear/android/app/memeolist/sdk/SyncClient.java
@@ -20,12 +20,11 @@ public final class SyncClient {
 
     private final ApolloClient apolloClient;
 
-    public SyncClient(QueryStoreWrapper queryStoreWrapper, @Nonnull OkHttpClient okHttpClient, @Nonnull String serverUrl,
+    public SyncClient(@Nonnull OkHttpClient okHttpClient, @Nonnull String serverUrl,
                       @Nonnull String webSocketUrl) {
         ApolloClient.Builder builder = ApolloClient.builder().serverUrl(nonNull(serverUrl, "serverUrl"))
                 .okHttpClient(nonNull(okHttpClient, "okHttpClient"))
                 .subscriptionTransportFactory(new Factory(webSocketUrl, okHttpClient));
-        queryStoreWrapper.create(builder, "memeo", "id");
         apolloClient = builder.build();
     }
 
@@ -35,9 +34,8 @@ public final class SyncClient {
             ServiceConfiguration configuration = mobileCore.getServiceConfigurationByType(TYPE);
             String serverUrl = configuration.getUrl();
             String webSocketUrl = configuration.getProperty("subscription");
-            QueryStoreWrapper queryStoreWrapper = new QueryStoreWrapper(mobileCore.getContext());
             OkHttpClient okHttpClient = mobileCore.getHttpLayer().getClient();
-            SyncClient.instance = new SyncClient(queryStoreWrapper, okHttpClient, serverUrl, webSocketUrl);
+            SyncClient.instance = new SyncClient(okHttpClient, serverUrl, webSocketUrl);
         }
         return instance;
     }


### PR DESCRIPTION
Using cache forces users to return entire object to reload required data. We currently returning only small amounts of data which means that username field could be empty etc. Additionally by default application is not making query to server (watch option should be used). 
For the moment we should disable cache layer and focus on adjusting server schema to return entire object that was changed in order to refresh it. Mutations should also return entire objects etc.