### PR TITLE
Fixed update of the meme list (needs to be executed in the main thread)

### DIFF
--- a/memeolist/app/src/main/java/org/aerogear/android/app/memeolist/ui/MemeListActivity.java
+++ b/memeolist/app/src/main/java/org/aerogear/android/app/memeolist/ui/MemeListActivity.java
@@ -201,6 +201,7 @@ public class MemeListActivity extends BaseActivity {
                 .getInstance()
                 .query(new AllMemesQuery())
                 .execute(AllMemesQuery.Data.class)
+                .respondOn(new AppExecutors().mainThread())
                 .respondWith(new Responder<Response<AllMemesQuery.Data>>() {
                     @Override
                     public void onResult(Response<AllMemesQuery.Data> response) {


### PR DESCRIPTION
retrieve meme was updating the UI out of the main thread, causing `IllegalStateException` error